### PR TITLE
Fix day numbering in example output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# autotrader-app
-AutoTrader react uygulaması
+# AutoTrader App
+AutoTrader React Uygulaması.
+
+## Python Example
+This repository now includes a simple trading strategy implemented in `src/autotrader.py`.
+
+### Running the script
+```
+python src/autotrader.py
+```
+
+### Running tests
+```
+python -m unittest discover -s tests
+```

--- a/src/autotrader.py
+++ b/src/autotrader.py
@@ -1,0 +1,42 @@
+from typing import List
+
+
+def moving_average(prices: List[float], window: int) -> List[float]:
+    """Compute the simple moving average."""
+    if window <= 0:
+        raise ValueError("window must be positive")
+    if len(prices) < window:
+        raise ValueError("window is larger than price data")
+
+    averages = []
+    current_sum = sum(prices[:window])
+    averages.append(current_sum / window)
+    for i in range(window, len(prices)):
+        current_sum += prices[i] - prices[i - window]
+        averages.append(current_sum / window)
+    return averages
+
+
+def generate_signals(prices: List[float], short_window: int = 5, long_window: int = 20) -> List[str]:
+    """Generate trading signals based on moving average crossover."""
+    if short_window >= long_window:
+        raise ValueError("short_window must be less than long_window")
+    short_ma = moving_average(prices, short_window)
+    long_ma = moving_average(prices, long_window)
+
+    offset = long_window - short_window
+    signals = []
+    for i in range(len(long_ma)):
+        if short_ma[i + offset] > long_ma[i]:
+            signals.append("BUY")
+        elif short_ma[i + offset] < long_ma[i]:
+            signals.append("SELL")
+        else:
+            signals.append("HOLD")
+    return signals
+
+if __name__ == "__main__":
+    sample = [100 + i * 0.5 for i in range(40)]
+    signals = generate_signals(sample)
+    for i, s in enumerate(signals, start=20):
+        print(f"Day {i}: {s}")

--- a/tests/test_autotrader.py
+++ b/tests/test_autotrader.py
@@ -1,0 +1,16 @@
+import unittest
+from src.autotrader import moving_average, generate_signals
+
+class TestAutoTrader(unittest.TestCase):
+    def test_moving_average(self):
+        prices = [1, 2, 3, 4, 5]
+        self.assertEqual(moving_average(prices, 3), [2.0, 3.0, 4.0])
+
+    def test_generate_signals(self):
+        prices = [i for i in range(1, 41)]
+        signals = generate_signals(prices, short_window=5, long_window=20)
+        # simple increasing sequence should always signal BUY
+        self.assertTrue(all(s == 'BUY' for s in signals))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- correct off-by-one error when printing day numbers

## Testing
- `python src/autotrader.py | head`
- `python -m unittest discover -s tests -v`


------
https://chatgpt.com/codex/tasks/task_e_6840a2ff934083209c284c01cf672c89